### PR TITLE
Add new API key regex to JSON and add common_pattern logic

### DIFF
--- a/dora/__main__.py
+++ b/dora/__main__.py
@@ -79,6 +79,13 @@ def main():
                         help="Don't show color in terminal output"
                         )
 
+    parser.add_argument("--common-patterns",
+                        action="store_true",
+                        default=False,
+                        help="Look for common API key patterns in addition to loading regex data from JSON. \
+                            Can yield false-positives."
+                        )
+
     args = parser.parse_args()
 
     # Catch SIGINT (also known as CTRL-C) and exit gracefully
@@ -91,6 +98,7 @@ def main():
     rg_path = args.rg_path
     rg_arguments = args.rg_arguments
     verbose = args.verbose
+    common_patterns = args.common_patterns
 
     # Create a printer object for displaying text.
     # We are making this global because exit_gracefully() also
@@ -122,6 +130,10 @@ def main():
         for item in data:
             regex = item.strip()
             service_name = item
+
+            if "Common_Pattern" in service_name and (not common_patterns):
+                continue
+
             regex = data.get(service_name).get("regex")
             # Awfully long variable name, I know. I'm open for suggestions.
             rg_args_from_json_data = data.get(service_name).get("flags")

--- a/dora/__main__.py
+++ b/dora/__main__.py
@@ -79,13 +79,6 @@ def main():
                         help="Don't show color in terminal output"
                         )
 
-    parser.add_argument("--common-patterns",
-                        action="store_true",
-                        default=False,
-                        help="Look for common API key patterns in addition to loading regex data from JSON. \
-                            Can yield false-positives."
-                        )
-
     args = parser.parse_args()
 
     # Catch SIGINT (also known as CTRL-C) and exit gracefully
@@ -98,7 +91,6 @@ def main():
     rg_path = args.rg_path
     rg_arguments = args.rg_arguments
     verbose = args.verbose
-    common_patterns = args.common_patterns
 
     # Create a printer object for displaying text.
     # We are making this global because exit_gracefully() also
@@ -130,9 +122,6 @@ def main():
         for item in data:
             regex = item.strip()
             service_name = item
-
-            if "Common_Pattern" in service_name and (not common_patterns):
-                continue
 
             regex = data.get(service_name).get("regex")
             # Awfully long variable name, I know. I'm open for suggestions.

--- a/dora/db/data.json
+++ b/dora/db/data.json
@@ -173,5 +173,19 @@
     },
     "Twilio API Key":{
         "regex": "(?i)twilio(.{0,20})?SK[0-9a-f]{32}"
+    },
+    "MongoDB Cloud Connection String":{
+        "regex": "mongodb\\+srv:\/\/(.*)"
+    },
+    "Riot Games Developer API Key":{
+        "regex": "RGAPI-[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+    },
+    "SerpAPI":{
+        "regex": "[a-f0-9]{64}",
+        "info": "Google Search API: https://serpapi.com/"
+    },
+    "Common_Pattern":{
+        "regex": "[a-fA-F0-9_-]{16,64}",
+        "info": "Look for common API key patterns in addition to loading regex data from JSON. Can yield false-positives"
     }
 }

--- a/dora/db/data.json
+++ b/dora/db/data.json
@@ -183,9 +183,5 @@
     "SerpAPI":{
         "regex": "[a-f0-9]{64}",
         "info": "Google Search API: https://serpapi.com/"
-    },
-    "Common_Pattern":{
-        "regex": "[a-fA-F0-9_-]{16,64}",
-        "info": "Look for common API key patterns in addition to loading regex data from JSON. Can yield false-positives"
     }
 }


### PR DESCRIPTION
This PR adds the regex for Riot Games Developer API Keys, MongoDB Cloud connection strings and SerpAPI keys.

Additionally, adding a common-pattern flag that allows for a more broader search of common API key patterns. However, this can yield false-positives.