### PR TITLE
docs: fix repo name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 # clone the repo
 $ git clone https://github.com/sdushantha/dora.git
 
-# change the working directory to sherlock
+# change the working directory to dora
 $ cd dora 
 
 # install dora


### PR DESCRIPTION
I changed the repo name to dora from sherlock in the install instructions section.